### PR TITLE
feat: make waybar background transparent and add reload shortcuts

### DIFF
--- a/configs/desktop/hypr/confs/keys.conf
+++ b/configs/desktop/hypr/confs/keys.conf
@@ -15,6 +15,8 @@ bind = $mainMod, V, togglefloating,
 bind = $mainMod, R, exec, wofi --conf ~/.config/wofi/config --style ~/.config/wofi/macchiato.css
 bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod, J, togglesplit, # dwindle
+bind = $mainMod, W, exec, pkill -USR2 waybar
+bind = $mainMod, H, exec, hyprctl reload
 
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l

--- a/configs/desktop/waybar/style.css
+++ b/configs/desktop/waybar/style.css
@@ -12,7 +12,7 @@
 /*----------------------------------------------*/
 
 #waybar {
-    background-color: @surface0;
+    background-color: transparent;
     transition-property: background-color;
     transition-duration: 0.5s;
 }


### PR DESCRIPTION
## Summary
- make waybar background transparent
- add keybinds to reload Waybar (Super+W) and Hyprland (Super+H)

## Testing
- `npm test` (fails: Could not read package.json)
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68946c3df978832c922ea6d90f6b4992